### PR TITLE
wait until each child terminates when kill all workers

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -273,6 +273,15 @@ module Resque
     def signal_all_workers(signal)
       all_pids.each do |pid|
         Process.kill signal, pid
+        log "kill sent, signal: #{signal}, pid: #{pid}"
+        if signal == :TERM || signal == :QUIT
+          begin
+            log "waiting to teminate, pid: #{pid}"
+            Process.waitpid(pid)
+            log "terminated, pid: #{pid}"
+          rescue Errno::ECHILD => e
+          end
+        end
       end
     end
 


### PR DESCRIPTION
reviewer: @ttakamura

resque-poolが一斉にworkerを停止させるせいでメモリ不足に陥る現象を回避するため、子プロセスの停止を1つずつ待つようにしました。
刺さったプロセスがいると停止処理そのものが止まりますが、その場合は今でも待ち状態になっているのであんまり違いはないかなと。
